### PR TITLE
Fixed output folder issue and fixed issue with options persisting to subsequent payload generations

### DIFF
--- a/beaconator.cna
+++ b/beaconator.cna
@@ -139,7 +139,7 @@ sub generateBeacon {
     printAll(@data);
     closef($process);
 
-    #reset options
+    # Reset options
     $hooks = "";
     $antidebug = "";
     $syscalls = "";

--- a/beaconator.cna
+++ b/beaconator.cna
@@ -139,6 +139,15 @@ sub generateBeacon {
     printAll(@data);
     closef($process);
 
+    #reset options
+    $hooks = "";
+    $antidebug = "";
+    $syscalls = "";
+    $sgn = "";
+    $text = "";
+    $rx = "";
+    $self = "";
+
     # Show message
     println("\c9[+] Success! Generated beacon can be found at " . script_resource($BUILD_DIR). ".");
     show_message("Success! Generated beacon can be found at " . script_resource($BUILD_DIR). ".");

--- a/output/.gitignore
+++ b/output/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Added folder "output" and added .gitignore to ignore the generated payloads but keep the folder. This fixes the null value error. 
Added code to reset the options back to null so that you don't have to reload the cna script after every payload generation.